### PR TITLE
Split failures and errors into dedicated categories

### DIFF
--- a/junit.go
+++ b/junit.go
@@ -14,11 +14,10 @@ import (
 const MatchAllSymbol = "*"
 
 // Counts provides a container for storing information about test counts.
-// "Failed" counts both JUnit "Failures" and "Errors" under a common field, as Reporter does not need
-// to distinguish between the two types: both cause the test run to be marked as unsuccessful.
 type Counts struct {
 	Passed  int
 	Failed  int
+	Errored int
 	Skipped int
 	Total   int
 }
@@ -29,6 +28,8 @@ func (c *Counts) Add(test junit.Test) {
 		c.Passed++
 	} else if test.Status == junit.StatusSkipped {
 		c.Skipped++
+	} else if test.Status == junit.StatusError {
+		c.Errored++
 	} else {
 		c.Failed++
 	}
@@ -57,6 +58,7 @@ func (r *AggregateReport) AggregateCounts() {
 	for _, suite := range r.TestSuites {
 		r.Counts.Passed += suite.Counts.Passed
 		r.Counts.Failed += suite.Counts.Failed
+		r.Counts.Errored += suite.Counts.Errored
 		r.Counts.Skipped += suite.Counts.Skipped
 		r.Counts.Total += suite.Counts.Total
 	}
@@ -78,7 +80,8 @@ func LogAggregateReports(logger *log.Logger, reports []AggregateReport) {
 			note = "(no data to upload)"
 		}
 
-		logger.Printf("%-3s Passed %-4d Failed %-4d Skipped %-4d Total %-4d -> Jira %s %s", fmt.Sprintf("%d)", i+1), c.Passed, c.Failed, c.Skipped, c.Total, dest, note)
+		logger.Printf("%-3s Passed %-4d Failed %-4d Errored %-4d Skipped %-4d Total %-4d -> Jira %s %s",
+			fmt.Sprintf("%d)", i+1), c.Passed, c.Failed, c.Errored, c.Skipped, c.Total, dest, note)
 	}
 }
 

--- a/templates/jira_subtask_desc.tmpl
+++ b/templates/jira_subtask_desc.tmpl
@@ -7,13 +7,14 @@ h1. Tests execution summary
 || Status || Number of test cases ||
 | ✔️ Passed | {{ .Counts.Passed }} |
 | ❌ Failed | {{ .Counts.Failed }} |
+| ⚠️ Errored | {{ .Counts.Errored }} |
 | 👟 Skipped | {{ .Counts.Skipped }} |
 | 🧮 *Total* | *{{ .Counts.Total }}* |
 
 h1. Tests execution detailed results
 
-|| Name || ✔️ Passed || ❌ Failed || 👟 Skipped || 🧮 *Total* ||
+|| Name || ✔️ Passed || ❌ Failed || ⚠️ Errored || 👟 Skipped || 🧮 *Total* ||
 {{- range .TestSuites }}
-| {{ .Name }} | {{ .Counts.Passed }} | {{ .Counts.Failed }} | {{ .Counts.Skipped }} | *{{ .Counts.Total }}* |
+| {{ .Name }} | {{ .Counts.Passed }} | {{ .Counts.Failed }} | {{ .Counts.Errored }} | {{ .Counts.Skipped }} | *{{ .Counts.Total }}* |
 {{- end }}
-| 🧮 *Total* | *{{ .Counts.Passed }}* | *{{ .Counts.Failed }}* | *{{ .Counts.Skipped }}* | *{{ .Counts.Total }}* |
+| 🧮 *Total* | *{{ .Counts.Passed }}* | *{{ .Counts.Failed }}* | *{{ .Counts.Errored }}* | *{{ .Counts.Skipped }}* | *{{ .Counts.Total }}* |

--- a/testdata/valid/simple_error.xml
+++ b/testdata/valid/simple_error.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" disabled="0" errors="1" failures="0" time="10.123456789">
+    <testsuite name="testdata.valid.simple" package="/var/lib/reporter/testdata"
+        tests="1" disabled="0" skipped="0" errors="1" failures="0" time="10.123456789"
+        timestamp="2024-01-02T03:04:05">
+        <testcase name="simple" classname="testdata.valid.simple" status="errored"
+            time="10.123456789">
+            <error message="This is an error message"/>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/testdata/valid/simple_failure.xml
+++ b/testdata/valid/simple_failure.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" disabled="0" errors="0" failures="1" time="10.123456789">
+    <testsuite name="testdata.valid.simple" package="/var/lib/reporter/testdata"
+        tests="1" disabled="0" skipped="0" errors="0" failures="1" time="10.123456789"
+        timestamp="2024-01-02T03:04:05">
+        <testcase name="simple" classname="testdata.valid.simple" status="failed"
+            time="10.123456789">
+            <failure message="This is a failure message"/>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/uploader.go
+++ b/uploader.go
@@ -43,7 +43,7 @@ func getIssueDesiredStateFields(report AggregateReport, config Config) (f IssueD
 	f.Description = buf.String()
 
 	f.Labels = desiredState.OnFailure.Labels
-	if report.Counts.Failed <= 0 {
+	if report.Counts.Failed == 0 && report.Counts.Errored == 0 {
 		f.Labels = desiredState.OnSuccess.Labels
 	}
 


### PR DESCRIPTION
This change introduces 'errors' as a new category in the issue template to help differentiate between failed test cases and execution errors.