### PR TITLE
Extend issue template with metadata section

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -132,6 +132,17 @@ $ reporter upload -d EXAMPLE-15
 
 In some scenarios, specifying one destination for all test results might not be practical. Refer to the next chapter to learn how to configure more advanced routing for test reports.
 
+=== Annotating results with custom metadata
+
+If you want to provide additional information such as artifact links, source commit hashes, release versions, etc you can use the `-m/--metadata` option. This CLI option can be repeated multiple times to enter as many metadata strings as needed.
+
+[source, text]
+-----
+$ reporter upload -d EXAMPLE-15 \
+    -m "CI Job URL = https://prow.ci.openshift.org" \
+    -m "Commit hash = a1b2c3d"
+-----
+
 == Advanced usage
 
 === Configuring routing rules

--- a/templates/cli_usage.tmpl
+++ b/templates/cli_usage.tmpl
@@ -22,16 +22,19 @@ Usage examples
   2) Upload a test report to Jira issue "EXAMPLE-15"
   {{ .ProgramName }} upload -i test-report.xml -d EXAMPLE-15
 
-  3) Upload all test reports at "artifacts/" and "junit/" to Jira issue "EXAMPLE-15"
+  3) Upload a test report to Jira annotated with custom metadata
+  {{ .ProgramName }} upload -i test-report.xml -m "CI=True" -m "Job URL=https://redhat.com"
+
+  4) Upload all test reports at "artifacts/" and "junit/" to Jira issue "EXAMPLE-15"
   {{ .ProgramName }} upload -i artifacts/ -i junit/ -d EXAMPLE-15
 
-  4) Upload all test reports at the default "input/" directory to Jira issue "EXAMPLE-15"
+  5) Upload all test reports at the default "input/" directory to Jira issue "EXAMPLE-15"
   {{ .ProgramName }} upload -d EXAMPLE-15
 
-  5) Load a custom config file and upload test reports
+  6) Load a custom config file and upload test reports
   {{ .ProgramName }} upload -c custom-config.yaml
 
-  6) Upload test reports to an alternative Jira server instance
+  7) Upload test reports to an alternative Jira server instance
   {{ .ProgramName }} upload -s "http://localhost:8080" -t "secret-token"
 
 Find more at: https://github.com/redhat-eets/reporter

--- a/templates/jira_subtask_desc.tmpl
+++ b/templates/jira_subtask_desc.tmpl
@@ -2,7 +2,7 @@
 This Sub-task has been automatically generated and is periodically updated with new information. All manual edits made to this Sub-task will eventually be discarded.
 {panel}
 
-h1. Tests execution summary
+h1. Summary
 
 || Status || Number of test cases ||
 | ✔️ Passed | {{ .Counts.Passed }} |
@@ -11,10 +11,19 @@ h1. Tests execution summary
 | 👟 Skipped | {{ .Counts.Skipped }} |
 | 🧮 *Total* | *{{ .Counts.Total }}* |
 
-h1. Tests execution detailed results
+h1. Detailed results
 
 || Name || ✔️ Passed || ❌ Failed || ⚠️ Errored || 👟 Skipped || 🧮 *Total* ||
 {{- range .TestSuites }}
 | {{ .Name }} | {{ .Counts.Passed }} | {{ .Counts.Failed }} | {{ .Counts.Errored }} | {{ .Counts.Skipped }} | *{{ .Counts.Total }}* |
 {{- end }}
 | 🧮 *Total* | *{{ .Counts.Passed }}* | *{{ .Counts.Failed }}* | *{{ .Counts.Errored }}* | *{{ .Counts.Skipped }}* | *{{ .Counts.Total }}* |
+
+{{ if .Metadata }}
+h1. Metadata
+
+|| Key || Value ||
+{{- range .Metadata }}
+| {{ .Key }} | {{ .Value }} |
+{{- end }}
+{{ end }}


### PR DESCRIPTION
This change introduces a new `-m/--metadata` CLI option that allows the end user to annotate the uploaded report with additional information.

The option accepts data in the 'key=value' format and can be provided multiple times.